### PR TITLE
Dependency updates.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,19 +13,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.0.tgz",
-      "integrity": "sha512-Bb1NjZCaiwTQC/ARL+MwDpgocdnwWDCaugvkGt6cxfBzQa8Whv1JybBoUEiBDKl8Ni3H3c7Fykwk7QChUsHRlg==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
+      "integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.0",
+        "@babel/generator": "^7.7.2",
         "@babel/helpers": "^7.7.0",
-        "@babel/parser": "^7.7.0",
+        "@babel/parser": "^7.7.2",
         "@babel/template": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "convert-source-map": "^1.1.0",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.7.2",
+        "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
@@ -44,12 +44,12 @@
           }
         },
         "@babel/generator": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
-          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+          "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.7.0",
+            "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
@@ -85,9 +85,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
-          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
           "dev": true
         },
         "@babel/template": {
@@ -102,31 +102,40 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
-          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+          "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.7.0",
+            "@babel/generator": "^7.7.2",
             "@babel/helper-function-name": "^7.7.0",
             "@babel/helper-split-export-declaration": "^7.7.0",
-            "@babel/parser": "^7.7.0",
-            "@babel/types": "^7.7.0",
+            "@babel/parser": "^7.7.2",
+            "@babel/types": "^7.7.2",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.7.1",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
-          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+          "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
           }
         }
       }
@@ -1130,12 +1139,12 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
-          "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+          "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.7.0",
+            "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
@@ -1171,9 +1180,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
-          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
+          "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
           "dev": true
         },
         "@babel/template": {
@@ -1188,17 +1197,17 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
-          "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+          "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.7.0",
+            "@babel/generator": "^7.7.2",
             "@babel/helper-function-name": "^7.7.0",
             "@babel/helper-split-export-declaration": "^7.7.0",
-            "@babel/parser": "^7.7.0",
-            "@babel/types": "^7.7.0",
+            "@babel/parser": "^7.7.2",
+            "@babel/types": "^7.7.2",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
@@ -1216,9 +1225,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.7.1",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
-          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+          "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -3708,9 +3717,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.6.tgz",
-      "integrity": "sha512-u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.1.tgz",
+      "integrity": "sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     ]
   },
   "devDependencies": {
-    "@babel/core": "^7.7.0",
+    "@babel/core": "^7.7.2",
     "@jitesoft/babel-preset-main": "^1.7.3",
     "@jitesoft/eslint-config": "^1.7.2",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
-    "core-js": "^3.3.6",
+    "core-js": "^3.4.1",
     "cross-env": "^6.0.3",
     "eslint": "^6.6.0",
     "jest": "^24.9.0",


### PR DESCRIPTION
Bump core-js from 3.3.6 to 3.4.1

Bumps [core-js](https://github.com/zloirock/core-js) from 3.3.6 to 3.4.1.
- [Release notes](https://github.com/zloirock/core-js/releases)
- [Changelog](https://github.com/zloirock/core-js/blob/master/CHANGELOG.md)
- [Commits](https://github.com/zloirock/core-js/compare/v3.3.6...v3.4.1)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Bump @babel/core from 7.7.0 to 7.7.2

Bumps [@babel/core](https://github.com/babel/babel) from 7.7.0 to 7.7.2.
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/master/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/compare/v7.7.0...v7.7.2)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>